### PR TITLE
remove unused attribute in AWS configuration schema

### DIFF
--- a/bin/tfwrapper
+++ b/bin/tfwrapper
@@ -42,7 +42,6 @@ stack_configuration_schema = Schema({
         },
         'credentials':{
             'profile': str,
-            'role': str
         }
     },
     Optional('azure'): {


### PR DESCRIPTION
It does not seem to be used anywhere in the code.
Tested with a brand new stack.