### PR TITLE
ci: show all commit types in release-please changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,21 @@
       "release-type": "python",
       "package-name": "claranet-tfwrapper",
       "include-component-in-tag": false,
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "docs", "section": "Documentation" },
+        { "type": "style", "section": "Styles" },
+        { "type": "chore", "section": "Miscellaneous Chores" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "test", "section": "Tests" },
+        { "type": "build", "section": "Build System" },
+        { "type": "ci", "section": "Continuous Integration" }
+      ]
     }
   }
 }


### PR DESCRIPTION
Adds an explicit `changelog-sections` map to `release-please-config.json` with no hidden types, so `chore`, `ci`, `docs`, `style`, `refactor`, `test` and `build` commits also show up in the release notes (previously only `feat`/`fix`/`perf`/`deps`/`revert` were visible).

Main effect: Renovate's `chore(deps):` dependency and action bumps now appear in the changelog instead of being silently dropped.

Note: this only changes changelog **display**. `chore`/`ci`/etc. commits still don't bump the version or open a release PR on their own — they get folded into the next real release. Once merged, the next `release.yml` run will rewrite the open `release 15.0.0` PR (#632) to include the previously-hidden commits.