### PR TITLE
ci: keep uv.lock project version in sync on release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,6 +19,13 @@
         { "type": "test", "section": "Tests" },
         { "type": "build", "section": "Build System" },
         { "type": "ci", "section": "Continuous Integration" }
+      ],
+      "extra-files": [
+        {
+          "path": "uv.lock",
+          "type": "toml",
+          "jsonpath": "$.package[?(@.name.value=='claranet-tfwrapper')].version"
+        }
       ]
     }
   }

--- a/uv.lock
+++ b/uv.lock
@@ -229,7 +229,7 @@ wheels = [
 
 [[package]]
 name = "claranet-tfwrapper"
-version = "14.0.8"
+version = "15.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },


### PR DESCRIPTION
## Problem

release-please bumps the version in `pyproject.toml` on release but doesn't touch `uv.lock`. After the 15.0.0 release merged, `uv.lock`'s recorded project version was still `14.0.8` while `pyproject.toml` was `15.0.0`. The lint job runs `uv run tox`, which re-locks, and `git diff --exit-code` then fails — so `master`'s `Tests` run went red right after the release (the release + PyPI publish themselves succeeded fine).

## Fix

- Sync `uv.lock`'s project version to `15.0.0` (unbreaks `master` lint now — this is the single line `uv lock` would change).
- Add an `extra-files` entry to `release-please-config.json` so release-please updates `uv.lock`'s version in future release PRs.

The jsonpath uses `@.name.value` (the TOML AST wraps `name`), per [googleapis/release-please#2561](https://github.com/googleapis/release-please/issues/2561). This keeps the lock consistent on every future release automatically.