### PR TITLE
build: adopt uv exclude-newer and source CI tool versions from mise

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,13 @@
 ---
+include:
+  - project: claranet/guildes/pipeline/helpers
+    ref: v4.13.5
+    file: tool_versions.yml
+
 variables:
   KUBERNETES_MEMORY_REQUEST: "600Mi"
   KUBERNETES_MEMORY_LIMIT: "1Gi"
   KUBERNETES_CPU_REQUEST: "1"
-  PYTHON_VERSION: "3.14"
-  UV_VERSION: "0.11.1"
 
 stages:
   - lint
@@ -13,16 +16,20 @@ stages:
 lint:
   stage: lint
   image: python:${PYTHON_VERSION}
+  needs:
+    - "tool versions"
   script:
     - pip install uv==${UV_VERSION}
     - uv run tox -e lint
 
 tox:
   stage: unit-test
-  image: python:${PYTHON_VERSION}
+  image: python:${PYTHON_TEST_VERSION}
+  needs:
+    - "tool versions"
   parallel:
     matrix:
-      - PYTHON_VERSION: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+      - PYTHON_TEST_VERSION: ["3.10", "3.11", "3.12", "3.13", "3.14"]
   script:
     - pip install uv==${UV_VERSION}
     - uv run tox -e coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,8 @@ test = [
 ]
 
 [tool.uv]
-default-groups = ["test"]
+default-groups = "all"
+exclude-newer = "7 days"
 
 [build-system]
 requires = ["hatchling"]

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "argcomplete"
 version = "3.7.0"
@@ -427,7 +431,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
## What

**`pyproject.toml` `[tool.uv]`**
- `exclude-newer = "7 days"` — cap lockfile resolution to artifacts at least 7 days old, matching the Renovate `minimumReleaseAge: "7 days"` policy so local `uv lock` / lockFileMaintenance and Renovate agree on what counts as "too new".
- `default-groups = "all"` (was `["test"]`) — include every dependency group by default.

**`uv.lock`** regenerated: only adds the relative `[options]` block (`exclude-newer-span = "P7D"`); nothing rolled back since no dependency was newer than 7 days. uv reads `exclude-newer` from `pyproject.toml`, so CI reproduces the same lock (no `git diff` churn in the lint job).

**`.gitlab-ci.yml`**: drop the hardcoded `UV_VERSION` (had drifted to `0.11.1` vs mise's `0.11.28`) and `PYTHON_VERSION`, sourcing both from the shared `tool versions` job that parses the mise config. The 3.10–3.14 test matrix is kept but renamed to `PYTHON_TEST_VERSION` — the dotenv-provided `PYTHON_VERSION` has higher CI variable precedence than `parallel:matrix`, so a same-named matrix var would collapse to a single version.

## Notes

- No Renovate change needed: `minimumReleaseAge` (gates PR creation) and `exclude-newer` (gates lock resolution) are complementary, both at 7 days.
- The relative window is recorded as a stable span, so `uv lock --check` / `uv run` don't re-lock as it slides forward — it only advances on an explicit re-resolution (dep bump, `uv lock --upgrade`, or lockFileMaintenance).
